### PR TITLE
Case-insensitive HTTP headers

### DIFF
--- a/fhir-rest/src/main/java/ee/fhir/fhirest/rest/model/FhirestRequest.java
+++ b/fhir-rest/src/main/java/ee/fhir/fhirest/rest/model/FhirestRequest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -24,7 +25,7 @@ public class FhirestRequest {
   private String type;
   private String path;
   private Map<String, List<String>> parameters = new LinkedHashMap<>();
-  private Map<String, List<String>> headers = new LinkedHashMap<>();
+  private final Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
   private String body;
   private List<MediaType> accept;
   private MediaType contentType;


### PR DESCRIPTION
Based on the HTTP 2.0 specification (https://www.rfc-editor.org/rfc/rfc9113#section-8.2), case should be ignored when comparing HTTP headers.

Currently, in some FhirEST places, a case-sensitive comparison is performed. For example, in [PreferredReturn.java](https://github.com/fhirest/fhirest/blob/master/fhir-rest/src/main/java/ee/fhir/fhirest/rest/util/PreferredReturn.java#L31), the header `Prefered` is getting ignored because Tomcat transforms headers into lowercase.

_P.S. Maybe Micronaut behaves differently, so it wasn't an issue there._


FhirEST: R1.0-SNAPSHOT
Spring Boot: 3.2.3