### PR TITLE
fix: search result returns duplicate resources

### DIFF
--- a/fhirest-core/src/main/java/ee/fhir/fhirest/core/service/resource/ResourceSearchService.java
+++ b/fhirest-core/src/main/java/ee/fhir/fhirest/core/service/resource/ResourceSearchService.java
@@ -148,7 +148,8 @@ public class ResourceSearchService {
               .filter(reference -> !contains(result, reference))
               .forEach(resourceIds::add)
           );
-      result.addIncludes(storageService.load(resourceIds));
+      List<VersionId> uniqueResourceIds = ResourceUtil.filterUnique(resourceIds);
+      result.addIncludes(storageService.load(uniqueResourceIds));
     }));
   }
 

--- a/fhirest-core/src/main/java/ee/fhir/fhirest/core/util/ResourceUtil.java
+++ b/fhirest-core/src/main/java/ee/fhir/fhirest/core/util/ResourceUtil.java
@@ -27,6 +27,9 @@ package ee.fhir.fhirest.core.util;
 import ee.fhir.fhirest.core.exception.FhirException;
 import ee.fhir.fhirest.core.exception.FhirestIssue;
 import ee.fhir.fhirest.core.model.VersionId;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
@@ -55,6 +58,13 @@ public final class ResourceUtil {
       id.setVersion(Integer.valueOf(tokens[3]));
     }
     return id;
+  }
+
+  public static List<VersionId> filterUnique(List<VersionId> versions) {
+    Set<String> seen = new HashSet<>();
+    return versions.stream()
+        .filter(version -> seen.add(version.getReference()))
+        .toList();
   }
 
 }


### PR DESCRIPTION
Problem:
When doing resource search with "include" parameter then in some cases it may return duplicate resources. The problem occurs when there are multiple references to the same resource. This happens because references are not filtered for duplicates and because references are queried in [batches of 100](https://github.com/fhirest/fhirest/blob/94a281557cd293c7afe732c1ec8264bfbe616d88/pg-store/src/main/java/ee/fhir/fhirest/store/repository/ResourceRepository.java#L92). So if the same reference is present in multiple batches then the same resource will be returned multiple times.

Fix:
Filter duplicate referenced VersionIds.