### PR TITLE
Bug question history query execution

### DIFF
--- a/pg-store/src/main/java/ee/fhir/fhirest/store/repository/ResourceRepository.java
+++ b/pg-store/src/main/java/ee/fhir/fhirest/store/repository/ResourceRepository.java
@@ -113,17 +113,20 @@ public class ResourceRepository {
     if (id.getVersion() != null) {
       sb.append(" AND version = ?", id.getVersion());
     } else {
-      sb.append(""" 
-                AND sys_status = (
-                SELECT CASE WHEN EXISTS (
-                  SELECT 1 FROM store.resource
-                  WHERE type = ? AND id = ? AND sys_status = 'A'
-                )
-                THEN 'A'
-                ELSE 'C'
-                END)
-                ORDER BY r.updated DESC
-                LIMIT 1""",  id.getResourceType(), id.getResourceId());
+      sb.append("""
+              AND sys_status = (
+                SELECT CASE
+                  WHEN EXISTS (
+                    SELECT 1 FROM store.resource
+                    WHERE type = ? AND id = ? AND sys_status = 'A'
+                  )
+                  THEN 'A'
+                  ELSE 'C'
+                END
+              )
+              ORDER BY r.updated DESC
+              LIMIT 1
+              """, id.getResourceType(), id.getResourceId());
     }
     pgResourceFilter.ifPresent(f -> f.filter(sb, "r"));
     try {


### PR DESCRIPTION
As the FHIR documentation suggests, deleting a FHIR resource should not remove its history. Based on the documentation, I assume that the full history (including delete events) should still be visible via GET /Questionnaire/[id]/_history. So I considered the actions described under this issue to be a bug. 

The described action description is available here: https://build.fhir.org/http.html#delete